### PR TITLE
Add retrieval evaluation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,42 @@ for file_path in ["doc1.docx", "doc2.pdf", "doc3.docx"]:
     print(f"Processed {len(chunks)} chunks from {file_path}")
 ```
 
+## Evaluating Retrieval Quality
+
+DocChunker ships a dependency-light evaluation framework to answer: "given this document and these queries, how well do the produced chunks support retrieval?" It includes a from-scratch BM25 retriever (no ML dependencies) and a config comparison helper to pick chunking parameters empirically.
+
+```python
+from docchunker import (
+    DocChunker, EvalDataset, EvalQuery, RetrievalEvaluator, compare_configs,
+)
+
+dataset = EvalDataset(
+    document_path="document.docx",
+    queries=[
+        EvalQuery(query="how does password recovery work",
+                  expected_substring="Password recovery"),
+        EvalQuery(query="which department owns the frontend",
+                  expected_keywords=["Frontend Team", "Engineering"]),
+    ],
+)
+# Datasets can also be loaded from JSON/YAML: EvalDataset.from_file("eval.yaml")
+
+# Evaluate one configuration
+evaluator = RetrievalEvaluator(DocChunker(chunk_size=500))
+report = evaluator.evaluate(dataset, k=5)
+print(report)  # hit_rate@5, MRR, chunk size stats, per-query ranks
+
+# Compare chunking configurations empirically
+comparison = compare_configs(
+    "document.docx", dataset,
+    configs=[{"chunk_size": 300}, {"chunk_size": 1000, "num_overlapping_elements": 1}],
+)
+print(comparison)          # table: chunks, mean size, hit_rate@k, MRR per config
+print(comparison.best())   # top-scoring config
+```
+
+To evaluate with an embedding-based retriever, implement the `Retriever` protocol (`index(chunks)` and `retrieve(query, k)`) and pass it to `RetrievalEvaluator` — DocChunker adds no embedding dependency. See `examples/retrieval_evaluation_demo.py` for a runnable end-to-end example.
+
 ## RAG DEMO
 For an end-to-end example of building a simple RAG system using DocChunker with LangChain, check out the `examples/RAG_demo.ipynb` notebook.
 
@@ -145,7 +181,7 @@ Use `num_overlapping_elements = 0` when:
 
 - [ ] **Chunk Size Homogenization**: Implement strategies to reduce chunk size variance.
 - [ ] **Enhanced Unit Testing**: Add more tests for complex tables and lists.
-- [ ] **Retrieval Evaluation Framework**: Develop a framework to assess chunk effectiveness.
+- [x] **Retrieval Evaluation Framework**: Develop a framework to assess chunk effectiveness.
 - [ ] **Increased Test Coverage**: Systematically improve overall code coverage.
 - [x] **PDF Support**: Full PDF parsing and chunking support with structure detection.
 - [x] **Element Overlap**: Configurable overlap between chunks for better context preservation.

--- a/docchunker/__init__.py
+++ b/docchunker/__init__.py
@@ -6,7 +6,28 @@ including tables, nested lists, and images in formats like DOCX and PDF.
 """
 
 from docchunker.chunker import DocChunker
+from docchunker.evaluation import (
+    Bm25Retriever,
+    EvalDataset,
+    EvalQuery,
+    EvalReport,
+    KeywordRetriever,
+    Retriever,
+    RetrievalEvaluator,
+    compare_configs,
+)
 from docchunker.models.chunk import Chunk
 
 __version__ = "0.1.4"
-__all__ = ["DocChunker", "Chunk"]
+__all__ = [
+    "DocChunker",
+    "Chunk",
+    "Bm25Retriever",
+    "EvalDataset",
+    "EvalQuery",
+    "EvalReport",
+    "KeywordRetriever",
+    "Retriever",
+    "RetrievalEvaluator",
+    "compare_configs",
+]

--- a/docchunker/evaluation/__init__.py
+++ b/docchunker/evaluation/__init__.py
@@ -1,0 +1,27 @@
+"""
+Retrieval evaluation framework: measure how well produced chunks support
+retrieval, and compare DocChunker configurations empirically.
+"""
+
+from docchunker.evaluation.dataset import EvalDataset, EvalQuery
+from docchunker.evaluation.evaluator import (
+    ConfigComparison,
+    EvalReport,
+    QueryResult,
+    RetrievalEvaluator,
+    compare_configs,
+)
+from docchunker.evaluation.retrievers import Bm25Retriever, KeywordRetriever, Retriever
+
+__all__ = [
+    "Bm25Retriever",
+    "ConfigComparison",
+    "EvalDataset",
+    "EvalQuery",
+    "EvalReport",
+    "KeywordRetriever",
+    "QueryResult",
+    "Retriever",
+    "RetrievalEvaluator",
+    "compare_configs",
+]

--- a/docchunker/evaluation/dataset.py
+++ b/docchunker/evaluation/dataset.py
@@ -1,0 +1,110 @@
+"""
+Evaluation dataset models: queries with relevance criteria against a document.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class EvalQuery:
+    """A single retrieval evaluation query.
+
+    A retrieved chunk is considered relevant to this query if it contains
+    ``expected_substring`` (case-insensitive), or if it contains at least a
+    configurable fraction of ``expected_keywords`` (see
+    ``RetrievalEvaluator.evaluate``'s ``keyword_threshold``).
+
+    Args:
+        query: The natural-language query text.
+        expected_keywords: Keywords the relevant chunk is expected to contain.
+        expected_substring: An exact substring the relevant chunk must contain.
+        id: Optional identifier for reporting. Defaults to the query text.
+    """
+
+    query: str
+    expected_keywords: list[str] = field(default_factory=list)
+    expected_substring: str | None = None
+    id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.expected_keywords and self.expected_substring is None:
+            raise ValueError(
+                f"EvalQuery {self.query!r} needs expected_keywords and/or expected_substring"
+            )
+        if self.id is None:
+            self.id = self.query
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EvalQuery":
+        return cls(
+            query=data["query"],
+            expected_keywords=list(data.get("expected_keywords", [])),
+            expected_substring=data.get("expected_substring"),
+            id=data.get("id"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "query": self.query,
+            "expected_keywords": self.expected_keywords,
+            "expected_substring": self.expected_substring,
+        }
+
+
+@dataclass
+class EvalDataset:
+    """A set of evaluation queries, optionally tied to a document path.
+
+    Args:
+        queries: The evaluation queries.
+        document_path: Path to the document the queries are written against.
+    """
+
+    queries: list[EvalQuery]
+    document_path: str | Path | None = None
+
+    def __len__(self) -> int:
+        return len(self.queries)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EvalDataset":
+        return cls(
+            queries=[EvalQuery.from_dict(q) for q in data.get("queries", [])],
+            document_path=data.get("document_path"),
+        )
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> "EvalDataset":
+        """Load a dataset from a JSON or YAML file.
+
+        Expected structure::
+
+            {
+              "document_path": "path/to/document.docx",   # optional
+              "queries": [
+                {"query": "...", "expected_keywords": ["..."],
+                 "expected_substring": "...", "id": "..."}
+              ]
+            }
+        """
+        path = Path(file_path)
+        with open(path, encoding="utf-8") as f:
+            if path.suffix.lower() in (".yaml", ".yml"):
+                data = yaml.safe_load(f)
+            else:
+                data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid dataset file (expected a mapping): {path}")
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "document_path": str(self.document_path) if self.document_path else None,
+            "queries": [q.to_dict() for q in self.queries],
+        }

--- a/docchunker/evaluation/evaluator.py
+++ b/docchunker/evaluation/evaluator.py
@@ -1,0 +1,285 @@
+"""
+Retrieval evaluation: score how well produced chunks support retrieval.
+"""
+
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from docchunker.chunker import DocChunker
+from docchunker.evaluation.dataset import EvalDataset, EvalQuery
+from docchunker.evaluation.retrievers import Bm25Retriever, Retriever
+from docchunker.models.chunk import Chunk
+
+
+def _chunk_matches_query(
+    chunk: Chunk, query: EvalQuery, keyword_threshold: float
+) -> bool:
+    """True if the chunk satisfies the query's relevance criterion."""
+    text = chunk.text.lower()
+    if query.expected_substring is not None:
+        if query.expected_substring.lower() in text:
+            return True
+    if query.expected_keywords:
+        found = sum(1 for kw in query.expected_keywords if kw.lower() in text)
+        if found / len(query.expected_keywords) >= keyword_threshold:
+            return True
+    return False
+
+
+def _percentile(sorted_values: list[int], fraction: float) -> float:
+    """Nearest-rank percentile over a pre-sorted list."""
+    if not sorted_values:
+        return 0.0
+    index = min(len(sorted_values) - 1, max(0, round(fraction * (len(sorted_values) - 1))))
+    return float(sorted_values[index])
+
+
+@dataclass
+class QueryResult:
+    """Outcome of a single evaluation query.
+
+    ``rank`` is the 1-based position of the first relevant chunk in the
+    top-k results, or None if no relevant chunk was retrieved.
+    """
+
+    query_id: str
+    query: str
+    rank: int | None
+    num_retrieved: int
+
+    @property
+    def hit(self) -> bool:
+        return self.rank is not None
+
+    @property
+    def reciprocal_rank(self) -> float:
+        return 1.0 / self.rank if self.rank is not None else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "query": self.query,
+            "rank": self.rank,
+            "hit": self.hit,
+            "reciprocal_rank": self.reciprocal_rank,
+            "num_retrieved": self.num_retrieved,
+        }
+
+
+@dataclass
+class EvalReport:
+    """Aggregated retrieval evaluation results for one chunking run."""
+
+    k: int
+    results: list[QueryResult]
+    num_chunks: int
+    mean_chunk_size: float
+    median_chunk_size: float
+    p95_chunk_size: float
+
+    @property
+    def hit_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(1 for r in self.results if r.hit) / len(self.results)
+
+    @property
+    def mrr(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.reciprocal_rank for r in self.results) / len(self.results)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "k": self.k,
+            "hit_rate": self.hit_rate,
+            "mrr": self.mrr,
+            "num_queries": len(self.results),
+            "num_chunks": self.num_chunks,
+            "mean_chunk_size": self.mean_chunk_size,
+            "median_chunk_size": self.median_chunk_size,
+            "p95_chunk_size": self.p95_chunk_size,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+    def __str__(self) -> str:
+        lines = [
+            f"Retrieval evaluation (k={self.k}, {len(self.results)} queries)",
+            f"  hit_rate@{self.k}: {self.hit_rate:.2f}",
+            f"  MRR:        {self.mrr:.3f}",
+            f"  chunks:     {self.num_chunks} "
+            f"(mean {self.mean_chunk_size:.0f} / median {self.median_chunk_size:.0f}"
+            f" / p95 {self.p95_chunk_size:.0f} chars)",
+            "",
+            f"  {'query':40} {'rank':>5}",
+            f"  {'-' * 40} {'-' * 5}",
+        ]
+        for result in self.results:
+            label = result.query_id if len(result.query_id) <= 40 else result.query_id[:37] + "..."
+            rank = str(result.rank) if result.rank is not None else "miss"
+            lines.append(f"  {label:40} {rank:>5}")
+        return "\n".join(lines)
+
+
+@dataclass
+class ConfigComparison:
+    """Result of ``compare_configs``: one (config, EvalReport) row per config."""
+
+    k: int
+    rows: list[tuple[dict[str, Any], EvalReport]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "k": self.k,
+            "rows": [
+                {"config": config, "report": report.to_dict()}
+                for config, report in self.rows
+            ],
+        }
+
+    def best(self) -> tuple[dict[str, Any], EvalReport]:
+        """The row with the highest hit rate (MRR breaks ties)."""
+        if not self.rows:
+            raise ValueError("No configs were compared")
+        return max(self.rows, key=lambda row: (row[1].hit_rate, row[1].mrr))
+
+    def __str__(self) -> str:
+        labels = [
+            ", ".join(f"{key}={value}" for key, value in config.items())
+            for config, _report in self.rows
+        ]
+        width = max([len("config")] + [len(label) for label in labels])
+        header = (
+            f"{'config':{width}} {'chunks':>6} {'mean_sz':>8} "
+            f"{'hit_rate@' + str(self.k):>10} {'mrr':>6}"
+        )
+        lines = [header, "-" * len(header)]
+        for label, (_config, report) in zip(labels, self.rows):
+            lines.append(
+                f"{label:{width}} {report.num_chunks:>6} "
+                f"{report.mean_chunk_size:>8.0f} {report.hit_rate:>10.2f} "
+                f"{report.mrr:>6.3f}"
+            )
+        return "\n".join(lines)
+
+
+class RetrievalEvaluator:
+    """Evaluates how well a chunker's output supports retrieval.
+
+    Chunks the dataset's document with ``chunker``, indexes the chunks with
+    ``retriever``, and checks for each query whether a relevant chunk appears
+    in the top-k results.
+
+    Args:
+        chunker: The DocChunker configuration under evaluation.
+        retriever: Any object implementing the ``Retriever`` protocol.
+            Defaults to ``Bm25Retriever``. Plug in an embedding-based
+            retriever here for semantic evaluation.
+    """
+
+    def __init__(self, chunker: DocChunker, retriever: Retriever | None = None):
+        self.chunker = chunker
+        self.retriever = retriever if retriever is not None else Bm25Retriever()
+
+    def evaluate(
+        self,
+        dataset: EvalDataset,
+        k: int = 5,
+        keyword_threshold: float = 0.8,
+        document_path: str | Path | None = None,
+    ) -> EvalReport:
+        """Chunk the document and evaluate all dataset queries.
+
+        Args:
+            dataset: Queries plus (optionally) the document path.
+            k: Number of chunks to retrieve per query.
+            keyword_threshold: Minimum fraction of ``expected_keywords`` a
+                chunk must contain to count as relevant. Default: 0.8.
+            document_path: Overrides ``dataset.document_path`` if given.
+
+        Returns:
+            An EvalReport with per-query ranks and aggregate metrics.
+        """
+        path = document_path if document_path is not None else dataset.document_path
+        if path is None:
+            raise ValueError(
+                "No document to evaluate: set dataset.document_path or pass document_path"
+            )
+        chunks = self.chunker.process_document(path)
+        return self.evaluate_chunks(chunks, dataset, k=k, keyword_threshold=keyword_threshold)
+
+    def evaluate_chunks(
+        self,
+        chunks: list[Chunk],
+        dataset: EvalDataset,
+        k: int = 5,
+        keyword_threshold: float = 0.8,
+    ) -> EvalReport:
+        """Evaluate dataset queries against pre-computed chunks."""
+        self.retriever.index(chunks)
+        results: list[QueryResult] = []
+        for query in dataset.queries:
+            retrieved = self.retriever.retrieve(query.query, k=k)
+            rank: int | None = None
+            for position, (chunk, _score) in enumerate(retrieved, start=1):
+                if _chunk_matches_query(chunk, query, keyword_threshold):
+                    rank = position
+                    break
+            results.append(
+                QueryResult(
+                    query_id=query.id or query.query,
+                    query=query.query,
+                    rank=rank,
+                    num_retrieved=len(retrieved),
+                )
+            )
+
+        sizes = sorted(len(chunk.text) for chunk in chunks)
+        return EvalReport(
+            k=k,
+            results=results,
+            num_chunks=len(chunks),
+            mean_chunk_size=statistics.mean(sizes) if sizes else 0.0,
+            median_chunk_size=statistics.median(sizes) if sizes else 0.0,
+            p95_chunk_size=_percentile(sizes, 0.95),
+        )
+
+
+def compare_configs(
+    document_path: str | Path,
+    dataset: EvalDataset,
+    configs: list[dict[str, Any]],
+    retriever_factory: Callable[[], Retriever] = Bm25Retriever,
+    k: int = 5,
+    keyword_threshold: float = 0.8,
+) -> ConfigComparison:
+    """Run the evaluator across several DocChunker configurations.
+
+    This is the main entry point for picking chunking parameters
+    empirically: pass candidate configs and compare hit rate / MRR.
+
+    Args:
+        document_path: Document to chunk under each configuration.
+        dataset: Evaluation queries.
+        configs: DocChunker keyword-argument dicts, e.g.
+            ``[{"chunk_size": 500}, {"chunk_size": 1000, "num_overlapping_elements": 1}]``.
+        retriever_factory: Zero-argument callable producing a fresh Retriever
+            per config. Default: ``Bm25Retriever``.
+        k: Number of chunks to retrieve per query.
+        keyword_threshold: See ``RetrievalEvaluator.evaluate``.
+
+    Returns:
+        A ConfigComparison; ``print()`` it for a summary table, or call
+        ``.best()`` for the top-scoring config.
+    """
+    comparison = ConfigComparison(k=k)
+    for config in configs:
+        chunker = DocChunker(**config)
+        evaluator = RetrievalEvaluator(chunker, retriever_factory())
+        report = evaluator.evaluate(
+            dataset, k=k, keyword_threshold=keyword_threshold, document_path=document_path
+        )
+        comparison.rows.append((config, report))
+    return comparison

--- a/docchunker/evaluation/retrievers.py
+++ b/docchunker/evaluation/retrievers.py
@@ -1,0 +1,125 @@
+"""
+Lightweight lexical retrievers used to evaluate chunk quality.
+
+Both built-in retrievers are dependency-free. To evaluate with an
+embedding-based retriever (sentence-transformers, OpenAI embeddings, a vector
+database, ...), implement the ``Retriever`` protocol -- ``index(chunks)`` and
+``retrieve(query, k)`` -- and pass your instance to ``RetrievalEvaluator``.
+No embedding dependency is required or bundled by DocChunker.
+"""
+
+import math
+import re
+from collections import Counter
+from typing import Protocol, runtime_checkable
+
+from docchunker.models.chunk import Chunk
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase word tokenizer shared by the built-in retrievers."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+@runtime_checkable
+class Retriever(Protocol):
+    """Minimal retriever interface for retrieval evaluation.
+
+    Any object with these two methods can be used with
+    ``RetrievalEvaluator`` -- e.g. a wrapper around an embedding model or a
+    vector store. Scores only need to be internally consistent (higher is
+    more relevant); they are never compared across retrievers.
+    """
+
+    def index(self, chunks: list[Chunk]) -> None:
+        """Build (or rebuild) the index over the given chunks."""
+        ...
+
+    def retrieve(self, query: str, k: int = 5) -> list[tuple[Chunk, float]]:
+        """Return the top-k chunks with scores, best first."""
+        ...
+
+
+class Bm25Retriever:
+    """BM25 (Okapi) ranking over chunk texts. No external dependencies.
+
+    Args:
+        k1: Term-frequency saturation parameter. Default: 1.5.
+        b: Length-normalization parameter. Default: 0.75.
+    """
+
+    def __init__(self, k1: float = 1.5, b: float = 0.75):
+        self.k1 = k1
+        self.b = b
+        self._chunks: list[Chunk] = []
+        self._doc_term_counts: list[Counter[str]] = []
+        self._doc_lengths: list[int] = []
+        self._avg_doc_length: float = 0.0
+        self._doc_freq: Counter[str] = Counter()
+
+    def index(self, chunks: list[Chunk]) -> None:
+        self._chunks = list(chunks)
+        self._doc_term_counts = []
+        self._doc_lengths = []
+        self._doc_freq = Counter()
+        for chunk in self._chunks:
+            tokens = tokenize(chunk.text)
+            counts = Counter(tokens)
+            self._doc_term_counts.append(counts)
+            self._doc_lengths.append(len(tokens))
+            self._doc_freq.update(counts.keys())
+        total = sum(self._doc_lengths)
+        self._avg_doc_length = total / len(self._chunks) if self._chunks else 0.0
+
+    def _idf(self, term: str) -> float:
+        n = len(self._chunks)
+        df = self._doc_freq.get(term, 0)
+        return math.log((n - df + 0.5) / (df + 0.5) + 1.0)
+
+    def retrieve(self, query: str, k: int = 5) -> list[tuple[Chunk, float]]:
+        query_terms = tokenize(query)
+        scored: list[tuple[Chunk, float]] = []
+        for chunk, counts, length in zip(
+            self._chunks, self._doc_term_counts, self._doc_lengths
+        ):
+            score = 0.0
+            for term in query_terms:
+                tf = counts.get(term, 0)
+                if tf == 0:
+                    continue
+                norm = 1.0 - self.b + self.b * (length / self._avg_doc_length)
+                score += self._idf(term) * tf * (self.k1 + 1) / (tf + self.k1 * norm)
+            if score > 0.0:
+                scored.append((chunk, score))
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return scored[:k]
+
+
+class KeywordRetriever:
+    """Baseline retriever scoring chunks by query-term overlap.
+
+    The score is the fraction of unique query terms present in the chunk.
+    Useful as a sanity baseline against BM25.
+    """
+
+    def __init__(self) -> None:
+        self._chunks: list[Chunk] = []
+        self._doc_terms: list[set[str]] = []
+
+    def index(self, chunks: list[Chunk]) -> None:
+        self._chunks = list(chunks)
+        self._doc_terms = [set(tokenize(chunk.text)) for chunk in self._chunks]
+
+    def retrieve(self, query: str, k: int = 5) -> list[tuple[Chunk, float]]:
+        query_terms = set(tokenize(query))
+        if not query_terms:
+            return []
+        scored: list[tuple[Chunk, float]] = []
+        for chunk, terms in zip(self._chunks, self._doc_terms):
+            overlap = len(query_terms & terms)
+            if overlap:
+                scored.append((chunk, overlap / len(query_terms)))
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return scored[:k]

--- a/examples/retrieval_evaluation_demo.py
+++ b/examples/retrieval_evaluation_demo.py
@@ -1,0 +1,125 @@
+"""
+Retrieval evaluation example for the DocChunker library.
+
+This example demonstrates how to:
+1. Build a small evaluation dataset (queries + relevance criteria)
+2. Evaluate how well the produced chunks support retrieval (BM25, no ML deps)
+3. Compare several chunking configurations empirically to pick parameters
+"""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to sys.path to import docchunker
+sys.path.append(str(Path(__file__).parent.parent))
+
+from docchunker import (
+    Bm25Retriever,
+    DocChunker,
+    EvalDataset,
+    EvalQuery,
+    KeywordRetriever,
+    RetrievalEvaluator,
+    compare_configs,
+)
+
+
+def build_dataset(document_path: Path) -> EvalDataset:
+    """Build a small evaluation dataset against data/unittests/nested_lists.docx.
+
+    Each query pairs realistic user phrasing with a relevance criterion:
+    either an exact substring the relevant chunk must contain, or a set of
+    expected keywords (a chunk is relevant when it contains at least
+    `keyword_threshold` of them).
+
+    Datasets can also be loaded from JSON/YAML via EvalDataset.from_file().
+    """
+    return EvalDataset(
+        document_path=document_path,
+        queries=[
+            EvalQuery(
+                id="password-recovery",
+                query="how does password recovery work",
+                expected_substring="Password recovery",
+            ),
+            EvalQuery(
+                id="frontend-team",
+                query="which department does the frontend team belong to",
+                expected_keywords=["Frontend Team", "Engineering"],
+            ),
+            EvalQuery(
+                id="testing-checklist",
+                query="what is in the testing checklist",
+                expected_keywords=["Testing Checklist", "Test case"],
+            ),
+            EvalQuery(
+                id="implementation-steps",
+                query="implementation steps for core features",
+                expected_substring="Implement Core Features",
+            ),
+        ],
+    )
+
+
+def main():
+    root_dir = Path(__file__).parent.parent
+    document_path = root_dir / "data" / "unittests" / "nested_lists.docx"
+
+    if not document_path.exists():
+        print(f"Document not found: {document_path}")
+        return
+
+    print("=== DocChunker Retrieval Evaluation Example ===")
+    print(f"Document: {document_path.name}")
+
+    dataset = build_dataset(document_path)
+    print(f"Dataset: {len(dataset)} queries")
+
+    # --- 1. Evaluate a single configuration with BM25 -----------------------
+    print("\n--- BM25 retriever, chunk_size=500 ---")
+    evaluator = RetrievalEvaluator(
+        chunker=DocChunker(chunk_size=500),
+        retriever=Bm25Retriever(),
+    )
+    report = evaluator.evaluate(dataset, k=5)
+    print(report)
+
+    # --- 2. Same configuration, keyword-overlap baseline --------------------
+    print("\n--- KeywordRetriever baseline, chunk_size=500 ---")
+    baseline_evaluator = RetrievalEvaluator(
+        chunker=DocChunker(chunk_size=500),
+        retriever=KeywordRetriever(),
+    )
+    baseline_report = baseline_evaluator.evaluate(dataset, k=5)
+    print(f"hit_rate@5: {baseline_report.hit_rate:.2f}  MRR: {baseline_report.mrr:.3f}")
+
+    # --- 3. Compare chunking configurations empirically ---------------------
+    # This is the point of the framework: pick chunk_size / overlap based on
+    # measured retrieval quality instead of guessing.
+    print("\n--- Config comparison (BM25, k=5) ---")
+    comparison = compare_configs(
+        document_path,
+        dataset,
+        configs=[
+            {"chunk_size": 300},
+            {"chunk_size": 500},
+            {"chunk_size": 1000},
+            {"chunk_size": 500, "num_overlapping_elements": 1},
+            {"chunk_size": 1000, "num_overlapping_elements": 2},
+        ],
+        retriever_factory=Bm25Retriever,
+        k=5,
+    )
+    print(comparison)
+
+    best_config, best_report = comparison.best()
+    print(f"\nBest config: {best_config} "
+          f"(hit_rate@5={best_report.hit_rate:.2f}, MRR={best_report.mrr:.3f})")
+
+    # To evaluate with your own embedding-based retriever, implement the
+    # Retriever protocol (index/retrieve) and pass it to RetrievalEvaluator --
+    # no changes to DocChunker required.
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,277 @@
+"""Tests for the retrieval evaluation framework."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from docchunker import DocChunker
+from docchunker.evaluation import (
+    Bm25Retriever,
+    EvalDataset,
+    EvalQuery,
+    KeywordRetriever,
+    Retriever,
+    RetrievalEvaluator,
+    compare_configs,
+)
+from docchunker.models.chunk import Chunk
+
+
+def make_chunk(text: str) -> Chunk:
+    return Chunk(text=text, metadata={"node_type": "paragraph"})
+
+
+SYNTHETIC_CHUNKS = [
+    make_chunk("The quick brown fox jumps over the lazy dog in the forest."),
+    make_chunk("Password recovery requires email verification and a reset token."),
+    make_chunk("The engineering department contains the frontend team and backend team."),
+    make_chunk("Quarterly revenue grew by twelve percent according to the finance report."),
+    make_chunk("The dog slept all day. The dog is very lazy. Dog dog dog."),
+]
+
+
+class TestBm25Retriever:
+    def test_ranks_relevant_chunk_first(self):
+        retriever = Bm25Retriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        results = retriever.retrieve("password recovery reset token", k=3)
+        assert results, "expected at least one result"
+        top_chunk, top_score = results[0]
+        assert "Password recovery" in top_chunk.text
+        assert top_score > 0
+
+    def test_scores_sorted_descending(self):
+        retriever = Bm25Retriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        results = retriever.retrieve("the lazy dog", k=5)
+        scores = [score for _, score in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_no_match_returns_empty(self):
+        retriever = Bm25Retriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        assert retriever.retrieve("zzz qqq xyzzy", k=5) == []
+
+    def test_respects_k(self):
+        retriever = Bm25Retriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        assert len(retriever.retrieve("the dog", k=1)) == 1
+
+    def test_idf_downweights_common_terms(self):
+        # "the" appears everywhere; "revenue" only in the finance chunk.
+        retriever = Bm25Retriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        results = retriever.retrieve("the revenue", k=5)
+        top_chunk, _ = results[0]
+        assert "revenue" in top_chunk.text.lower()
+
+
+class TestKeywordRetriever:
+    def test_overlap_scoring(self):
+        retriever = KeywordRetriever()
+        retriever.index(SYNTHETIC_CHUNKS)
+        results = retriever.retrieve("frontend team engineering", k=2)
+        top_chunk, top_score = results[0]
+        assert "frontend team" in top_chunk.text.lower()
+        assert top_score == 1.0  # all three query terms present
+
+    def test_satisfies_retriever_protocol(self):
+        assert isinstance(KeywordRetriever(), Retriever)
+        assert isinstance(Bm25Retriever(), Retriever)
+
+
+class TestEvalQuery:
+    def test_requires_a_relevance_criterion(self):
+        with pytest.raises(ValueError):
+            EvalQuery(query="no criteria")
+
+    def test_id_defaults_to_query(self):
+        query = EvalQuery(query="q1", expected_keywords=["a"])
+        assert query.id == "q1"
+
+
+class TestEvaluatorMath:
+    """Hit/miss and MRR math on synthetic chunks."""
+
+    def _evaluate(self, queries, k=3, keyword_threshold=0.8):
+        dataset = EvalDataset(queries=queries)
+        evaluator = RetrievalEvaluator(DocChunker(), Bm25Retriever())
+        return evaluator.evaluate_chunks(
+            SYNTHETIC_CHUNKS, dataset, k=k, keyword_threshold=keyword_threshold
+        )
+
+    def test_hit_at_rank_one(self):
+        report = self._evaluate(
+            [EvalQuery(query="password recovery token", expected_substring="reset token")]
+        )
+        assert report.results[0].rank == 1
+        assert report.hit_rate == 1.0
+        assert report.mrr == 1.0
+
+    def test_miss(self):
+        report = self._evaluate(
+            [EvalQuery(query="password recovery", expected_substring="not in any chunk")]
+        )
+        assert report.results[0].rank is None
+        assert report.hit_rate == 0.0
+        assert report.mrr == 0.0
+
+    def test_mrr_averages_reciprocal_ranks(self):
+        report = self._evaluate(
+            [
+                # Hit at rank 1.
+                EvalQuery(query="password recovery token", expected_substring="reset token"),
+                # Miss: query matches chunks, but criterion never satisfied.
+                EvalQuery(query="lazy dog", expected_substring="not present anywhere"),
+            ]
+        )
+        assert report.hit_rate == 0.5
+        assert report.mrr == pytest.approx(0.5)
+
+    def test_rank_two_hit(self):
+        # "dog dog dog" chunk outranks the fox chunk for this query;
+        # the substring criterion only matches the fox chunk.
+        report = self._evaluate(
+            [EvalQuery(query="lazy dog", expected_substring="quick brown fox")]
+        )
+        assert report.results[0].rank == 2
+        assert report.mrr == pytest.approx(0.5)
+
+    def test_keyword_threshold(self):
+        # 2 of 3 keywords present in the finance chunk (~0.67).
+        query_kwargs = {
+            "query": "quarterly revenue",
+            "expected_keywords": ["revenue", "finance", "nonexistent"],
+        }
+        strict = self._evaluate([EvalQuery(**query_kwargs)], keyword_threshold=0.8)
+        assert strict.results[0].rank is None
+        lenient = self._evaluate([EvalQuery(**query_kwargs)], keyword_threshold=0.5)
+        assert lenient.results[0].rank == 1
+
+    def test_chunk_size_stats(self):
+        report = self._evaluate(
+            [EvalQuery(query="dog", expected_keywords=["dog"])]
+        )
+        sizes = [len(c.text) for c in SYNTHETIC_CHUNKS]
+        assert report.num_chunks == len(SYNTHETIC_CHUNKS)
+        assert report.mean_chunk_size == pytest.approx(sum(sizes) / len(sizes))
+        assert min(sizes) <= report.median_chunk_size <= max(sizes)
+        assert report.p95_chunk_size <= max(sizes)
+
+    def test_report_serialization(self):
+        report = self._evaluate(
+            [EvalQuery(query="dog", expected_keywords=["dog"], id="dog-query")]
+        )
+        data = report.to_dict()
+        assert set(data) >= {
+            "k", "hit_rate", "mrr", "num_queries", "num_chunks",
+            "mean_chunk_size", "median_chunk_size", "p95_chunk_size", "results",
+        }
+        assert data["results"][0]["query_id"] == "dog-query"
+        text = str(report)
+        assert "hit_rate" in text and "dog-query" in text
+
+
+class TestDatasetLoading:
+    PAYLOAD = {
+        "document_path": "some/doc.docx",
+        "queries": [
+            {
+                "id": "q1",
+                "query": "how do I reset my password",
+                "expected_substring": "Password recovery",
+            },
+            {
+                "query": "team structure",
+                "expected_keywords": ["frontend", "backend"],
+            },
+        ],
+    }
+
+    def _check(self, dataset: EvalDataset):
+        assert dataset.document_path == "some/doc.docx"
+        assert len(dataset) == 2
+        assert dataset.queries[0].id == "q1"
+        assert dataset.queries[0].expected_substring == "Password recovery"
+        assert dataset.queries[1].expected_keywords == ["frontend", "backend"]
+
+    def test_from_json(self, tmp_path: Path):
+        path = tmp_path / "dataset.json"
+        path.write_text(json.dumps(self.PAYLOAD), encoding="utf-8")
+        self._check(EvalDataset.from_file(path))
+
+    def test_from_yaml(self, tmp_path: Path):
+        path = tmp_path / "dataset.yaml"
+        path.write_text(yaml.safe_dump(self.PAYLOAD), encoding="utf-8")
+        self._check(EvalDataset.from_file(path))
+
+    def test_roundtrip(self):
+        dataset = EvalDataset.from_dict(self.PAYLOAD)
+        assert EvalDataset.from_dict(dataset.to_dict()).to_dict() == dataset.to_dict()
+
+    def test_evaluate_without_document_path_raises(self):
+        dataset = EvalDataset(queries=[EvalQuery(query="q", expected_keywords=["q"])])
+        evaluator = RetrievalEvaluator(DocChunker())
+        with pytest.raises(ValueError):
+            evaluator.evaluate(dataset)
+
+
+class TestEndToEnd:
+    DOCUMENT = Path(__file__).parent.parent / "data" / "unittests" / "nested_lists.docx"
+
+    DATASET = EvalDataset(
+        queries=[
+            EvalQuery(
+                id="password-recovery",
+                query="password recovery",
+                expected_substring="Password recovery",
+            ),
+            EvalQuery(
+                id="frontend-team",
+                query="frontend team organizational structure",
+                expected_keywords=["Frontend Team"],
+            ),
+            EvalQuery(
+                id="unanswerable",
+                query="giraffe astrophysics",
+                expected_substring="this text does not appear in the document",
+            ),
+        ],
+    )
+
+    def test_evaluate_real_document(self):
+        evaluator = RetrievalEvaluator(DocChunker(chunk_size=500), Bm25Retriever())
+        report = evaluator.evaluate(self.DATASET, k=5, document_path=self.DOCUMENT)
+
+        assert report.num_chunks > 0
+        assert len(report.results) == 3
+        assert 0.0 <= report.hit_rate <= 1.0
+        assert 0.0 <= report.mrr <= 1.0
+        for result in report.results:
+            assert result.rank is None or 1 <= result.rank <= 5
+        # The unanswerable query must never be a hit.
+        by_id = {r.query_id: r for r in report.results}
+        assert by_id["unanswerable"].rank is None
+        # Report renders without error.
+        assert "hit_rate" in str(report)
+
+    def test_compare_configs(self):
+        comparison = compare_configs(
+            self.DOCUMENT,
+            self.DATASET,
+            configs=[
+                {"chunk_size": 300},
+                {"chunk_size": 1000, "num_overlapping_elements": 1},
+            ],
+            k=5,
+        )
+        assert len(comparison.rows) == 2
+        for config, report in comparison.rows:
+            assert "chunk_size" in config
+            assert report.num_chunks > 0
+        best_config, best_report = comparison.best()
+        assert best_report.hit_rate == max(r.hit_rate for _, r in comparison.rows)
+        table = str(comparison)
+        assert "hit_rate@5" in table and "chunk_size=300" in table


### PR DESCRIPTION
## Summary

Implements the **Retrieval Evaluation Framework** roadmap item: a dependency-light `docchunker/evaluation/` module that answers *"given this document and these queries, how well do the produced chunks support retrieval?"* — entirely rule-based, no ML dependencies added.

## Design

- **`evaluation/dataset.py`** — `EvalQuery` (query text + relevance criterion: an `expected_substring` the relevant chunk must contain and/or `expected_keywords` with a configurable coverage threshold, default 80%) and `EvalDataset`, loadable from JSON or YAML via `EvalDataset.from_file()`.
- **`evaluation/retrievers.py`** — a `Retriever` protocol (`index(chunks)` / `retrieve(query, k)`) with two zero-dependency built-ins:
  - `Bm25Retriever`: Okapi BM25 implemented from scratch (lowercase word-regex tokenization, k1=1.5, b=0.75)
  - `KeywordRetriever`: query-term-overlap baseline
- **`evaluation/evaluator.py`** — `RetrievalEvaluator(chunker, retriever)` with `evaluate(dataset, k=5, keyword_threshold=0.8)` returning an `EvalReport`: per-query rank of the first relevant chunk (or miss), `hit_rate@k`, MRR, chunk count and mean/median/p95 chunk size. Includes `to_dict()` and a readable `__str__` table. `evaluate_chunks()` lets you score pre-computed chunks directly.
- **`compare_configs(document_path, dataset, configs, retriever_factory=Bm25Retriever)`** — runs the evaluator across several `DocChunker` configurations and returns a comparison table, so users can pick `chunk_size` / `num_overlapping_elements` empirically instead of guessing. `.best()` returns the top-scoring config.

## Example output

From `examples/retrieval_evaluation_demo.py` against `data/unittests/nested_lists.docx`:

```
Retrieval evaluation (k=5, 4 queries)
  hit_rate@5: 1.00
  MRR:        0.875
  chunks:     17 (mean 209 / median 89 / p95 481 chars)

  query                                     rank
  ---------------------------------------- -----
  password-recovery                            1
  frontend-team                                1
  testing-checklist                            2
  implementation-steps                         1

config                                      chunks  mean_sz hit_rate@5    mrr
------------------------------------------------------------------------------
chunk_size=300                                  20      183       1.00  0.812
chunk_size=500                                  17      209       1.00  0.875
chunk_size=1000                                 14      245       1.00  0.875
chunk_size=500, num_overlapping_elements=1      17      216       1.00  0.833
chunk_size=1000, num_overlapping_elements=2     14      252       1.00  0.875
```

## Pluggable retrievers

The `Retriever` protocol is the extension point: any object with `index(chunks)` and `retrieve(query, k) -> list[tuple[Chunk, float]]` works — e.g. a sentence-transformers or vector-store wrapper — passed straight into `RetrievalEvaluator`. DocChunker deliberately bundles **no** embedding dependency; the built-in lexical retrievers keep the default install light.

## Testing

- 22 new tests in `tests/test_evaluation.py`: BM25 ranking sanity (relevance, ordering, IDF down-weighting of common terms), evaluator hit/miss/MRR math on synthetic `Chunk`s, keyword-threshold behavior, JSON/YAML dataset loading, report serialization, and an end-to-end run + config comparison on `data/unittests/nested_lists.docx`.
- Full suite: **54 passed, 6 xfailed** (previously 32 passed, 6 xfailed).

Public names are exported from both `docchunker.evaluation` and the top-level `docchunker` package; the only changes outside the new module are the top-level export list, README (roadmap tick + "Evaluating Retrieval Quality" section), tests, and the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)