### PR TITLE
Chunk size homogenization: split oversized paragraphs, merge undersized ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ pytest
 
 - **`chunk_size`** (int, default: 1000): Target number of characters per chunk. Chunks may exceed this size to maintain semantic cohesion.
 
+- **`min_chunk_size`** (int, default: `chunk_size // 4`): Minimum target number of characters per paragraph chunk. Consecutive small paragraphs under the same heading context are merged into a single chunk (metadata `node_type: "paragraph_group"`) until this size is reached, while the combined chunk stays within `chunk_size`. Single paragraphs larger than `chunk_size` are split at sentence boundaries into multiple chunks (metadata `is_split`, `split_index`, `split_total`). Set to `1` to effectively disable paragraph merging. Only affects paragraph chunks; table and list chunking are unchanged.
+
 - **`num_overlapping_elements`** (int, default: 0): Number of elements (list items, table rows) to overlap between adjacent chunks. This provides better context continuity for information retrieval:
   - `0`: No overlap - each element appears in only one chunk
   - `1-3`: Recommended for most use cases - provides context while minimizing duplication  
@@ -143,7 +145,7 @@ Use `num_overlapping_elements = 0` when:
 
 ## Future Roadmap
 
-- [ ] **Chunk Size Homogenization**: Implement strategies to reduce chunk size variance.
+- [x] **Chunk Size Homogenization**: Implement strategies to reduce chunk size variance.
 - [ ] **Enhanced Unit Testing**: Add more tests for complex tables and lists.
 - [ ] **Retrieval Evaluation Framework**: Develop a framework to assess chunk effectiveness.
 - [ ] **Increased Test Coverage**: Systematically improve overall code coverage.

--- a/docchunker/chunker.py
+++ b/docchunker/chunker.py
@@ -17,17 +17,21 @@ class DocChunker:
     format processing to specialized processors.
     
     Args:
-        chunk_size (int): Target number of characters per chunk. Default: 200.
+        chunk_size (int): Target number of characters per chunk. Default: 1000.
         num_overlapping_elements (int): Number of elements to overlap between chunks. Default: 0.
+        min_chunk_size (int | None): Minimum target number of characters per paragraph chunk.
+            Consecutive small paragraphs under the same heading context are merged until
+            this size is reached (while staying within chunk_size). Defaults to chunk_size // 4.
     """
 
-    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0):
+    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0, min_chunk_size: int | None = None):
         self.chunk_size = chunk_size
         self.num_overlapping_elements = num_overlapping_elements
+        self.min_chunk_size = min_chunk_size
 
         self.processors = {
-            "docx": DocxProcessor(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements),
-            "pdf": PdfProcessor(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements),
+            "docx": DocxProcessor(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size),
+            "pdf": PdfProcessor(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size),
         }
 
     def process_document(self, file_path: str | Path) -> list[Chunk]:

--- a/docchunker/processors/base_processor.py
+++ b/docchunker/processors/base_processor.py
@@ -8,9 +8,10 @@ class BaseProcessor:
     Base class for document processors.
     """
 
-    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0):
+    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0, min_chunk_size: int | None = None):
         self.chunk_size = chunk_size
         self.num_overlapping_elements = num_overlapping_elements
+        self.min_chunk_size = min_chunk_size
 
     def process(self, file_input: Union[str, BinaryIO]) -> list[Chunk]:
         """Process the document and return chunks.

--- a/docchunker/processors/document_chunker.py
+++ b/docchunker/processors/document_chunker.py
@@ -13,9 +13,15 @@ class DocumentChunker:
     chunking with overlap support for lists, tables, and other complex structures.
     """
     
-    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0):
+    SENTENCE_BOUNDARY_REGEX = re.compile(r"(?<=[.!?])\s+")
+    PARAGRAPH_SEPARATOR = "\n\n"
+
+    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0, min_chunk_size: int | None = None):
         self.chunk_size = chunk_size
         self.num_overlapping_elements = num_overlapping_elements
+        # Paragraph chunks smaller than this are merged with adjacent paragraphs
+        # sharing the same heading context (while staying within chunk_size).
+        self.min_chunk_size = min_chunk_size if min_chunk_size is not None else max(1, chunk_size // 4)
 
     def _stringify_node_content(self, node: dict[str, Any], indent_level: int = 0) -> str:
         """
@@ -228,9 +234,143 @@ class DocumentChunker:
             }
             chunks.append(Chunk(text=final_chunk_text, metadata=metadata))
 
+    def _split_text_into_sentences(self, text: str) -> list[str]:
+        """Splits text at sentence boundaries using a simple rule-based regex."""
+        sentences = [s for s in self.SENTENCE_BOUNDARY_REGEX.split(text) if s.strip()]
+        return sentences if sentences else [text]
+
+    def _split_oversized_paragraph(self, content: str, available_chars: int) -> list[str]:
+        """
+        Splits paragraph content that exceeds the available space into pieces.
+
+        Splitting happens at sentence boundaries; a hard character split is used
+        only as a fallback when a single sentence alone exceeds the available space.
+        """
+        pieces: list[str] = []
+        current_parts: list[str] = []
+        current_len = 0
+
+        for sentence in self._split_text_into_sentences(content):
+            sentence_len = len(sentence)
+            separator_len = 1 if current_parts else 0  # sentences are re-joined with " "
+
+            if current_parts and current_len + separator_len + sentence_len > available_chars:
+                pieces.append(" ".join(current_parts))
+                current_parts = []
+                current_len = 0
+
+            if sentence_len > available_chars:
+                # Fallback: hard character split for a single overlong sentence.
+                for start in range(0, sentence_len, available_chars):
+                    piece = sentence[start:start + available_chars]
+                    if len(piece) == available_chars:
+                        pieces.append(piece)
+                    else:
+                        current_parts = [piece]
+                        current_len = len(piece)
+            else:
+                current_parts.append(sentence)
+                current_len += separator_len + sentence_len
+
+        if current_parts:
+            pieces.append(" ".join(current_parts))
+        return pieces
+
+    def _emit_paragraph_group(self, paragraph_texts: list[str], current_headings: list[str], chunks: list[Chunk], document_id: str, source_format: str):
+        """Emits one chunk for a group of one or more merged paragraphs."""
+        if not paragraph_texts:
+            return
+        content = self.PARAGRAPH_SEPARATOR.join(paragraph_texts)
+        chunk_text = self._create_chunk_text(current_headings, content)
+        metadata: dict[str, Any] = {
+            "document_id": document_id,
+            "source_type": source_format,
+            "node_type": "paragraph" if len(paragraph_texts) == 1 else "paragraph_group",
+            "headings": list(current_headings),
+            "num_chars": len(chunk_text),
+        }
+        if len(paragraph_texts) > 1:
+            metadata["num_merged_elements"] = len(paragraph_texts)
+        chunks.append(Chunk(text=chunk_text, metadata=metadata))
+
+    def _emit_split_paragraph(self, content: str, current_headings: list[str], chunks: list[Chunk], document_id: str, source_format: str, available_chars: int):
+        """Emits multiple chunks for a single paragraph larger than the chunk size."""
+        pieces = self._split_oversized_paragraph(content, available_chars)
+        split_total = len(pieces)
+        for split_index, piece in enumerate(pieces):
+            chunk_text = self._create_chunk_text(current_headings, piece)
+            metadata = {
+                "document_id": document_id,
+                "source_type": source_format,
+                "node_type": "paragraph",
+                "headings": list(current_headings),
+                "num_chars": len(chunk_text),
+                "is_split": True,
+                "split_index": split_index,
+                "split_total": split_total,
+            }
+            chunks.append(Chunk(text=chunk_text, metadata=metadata))
+
+    def _flush_paragraph_buffer(self, paragraph_buffer: list[str], current_headings: list[str], chunks: list[Chunk], document_id: str, source_format: str):
+        """
+        Flushes buffered consecutive paragraphs (same heading context) as chunks.
+
+        Homogenization rules:
+        - A paragraph that would exceed chunk_size on its own is split at
+          sentence boundaries into multiple chunks.
+        - Consecutive paragraphs are merged while the current group is smaller
+          than min_chunk_size and the combined chunk stays within chunk_size.
+        """
+        if not paragraph_buffer:
+            return
+
+        headings_chars = len(self._create_chunk_text(current_headings, ""))
+        available_chars = max(self.chunk_size - headings_chars, self.min_chunk_size)
+
+        current_group: list[str] = []
+        current_content_chars = 0
+
+        for paragraph_text in paragraph_buffer:
+            paragraph_chars = len(paragraph_text)
+
+            if paragraph_chars > available_chars:
+                # Oversized paragraph: flush any pending group, then split it.
+                self._emit_paragraph_group(current_group, current_headings, chunks, document_id, source_format)
+                current_group = []
+                current_content_chars = 0
+                self._emit_split_paragraph(paragraph_text, current_headings, chunks, document_id, source_format, available_chars)
+                continue
+
+            separator_chars = len(self.PARAGRAPH_SEPARATOR) if current_group else 0
+            group_is_large_enough = (headings_chars + current_content_chars) >= self.min_chunk_size
+            would_overflow = current_content_chars + separator_chars + paragraph_chars > available_chars
+
+            if current_group and (group_is_large_enough or would_overflow):
+                self._emit_paragraph_group(current_group, current_headings, chunks, document_id, source_format)
+                current_group = []
+                current_content_chars = 0
+                separator_chars = 0
+
+            current_group.append(paragraph_text)
+            current_content_chars += separator_chars + paragraph_chars
+
+        self._emit_paragraph_group(current_group, current_headings, chunks, document_id, source_format)
+        paragraph_buffer.clear()
+
     def _consolidate_recursive(self, nodes: list[dict[str, Any]], current_headings: list[str], chunks: list[Chunk], document_id: str, source_format: str = "docx"):
+        paragraph_buffer: list[str] = []
+
         for node in nodes:
             node_type = node.get('type')
+
+            if node_type == 'paragraph':
+                stringified_content = self._stringify_node_content(node, indent_level=0)
+                if stringified_content.strip():
+                    paragraph_buffer.append(stringified_content)
+                continue
+
+            # Any non-paragraph node breaks the run of consecutive paragraphs.
+            self._flush_paragraph_buffer(paragraph_buffer, current_headings, chunks, document_id, source_format)
 
             if node_type == 'heading':
                 new_headings = list(current_headings)
@@ -250,19 +390,7 @@ class DocumentChunker:
             elif node_type == 'table':
                 self._process_table_node(node, current_headings, chunks, document_id, source_format)
 
-            elif node_type == 'paragraph':
-                stringified_content = self._stringify_node_content(node, indent_level=0)
-                if stringified_content.strip():
-                    chunk_text = self._create_chunk_text(current_headings, stringified_content)
-                    #TODO: If a single paragraph/table + headings is too large, it will be oversized.
-                    metadata = {
-                        "document_id": document_id,
-                        "source_type": source_format,
-                        "node_type": node_type,
-                        "headings": list(current_headings),
-                        "num_chars": len(chunk_text)
-                    }
-                    chunks.append(Chunk(text=chunk_text, metadata=metadata))
+        self._flush_paragraph_buffer(paragraph_buffer, current_headings, chunks, document_id, source_format)
 
 
     def apply(self, elements: list[dict[str, Any]], document_id: str, source_format: str = "docx") -> list[Chunk]:

--- a/docchunker/processors/docx_processor.py
+++ b/docchunker/processors/docx_processor.py
@@ -7,10 +7,10 @@ from docchunker.processors.docx_parser import DocxParser
 
 class DocxProcessor(BaseProcessor):
     """Main processor that orchestrates parsing and chunking"""
-    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0):
-        super().__init__(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements)
+    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0, min_chunk_size: int | None = None):
+        super().__init__(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size)
         self.parser = DocxParser()
-        self.chunker = DocumentChunker(chunk_size, num_overlapping_elements=num_overlapping_elements)
+        self.chunker = DocumentChunker(chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size)
 
     def process(self, file_input: str | BinaryIO) -> list[Chunk]:
         """Process DOCX file and return chunks.

--- a/docchunker/processors/pdf_processor.py
+++ b/docchunker/processors/pdf_processor.py
@@ -17,11 +17,11 @@ class PdfProcessor(BaseProcessor):
     with special handling for complex structures like tables and lists.
     """
 
-    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0):
-        super().__init__(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements)
+    def __init__(self, chunk_size: int = 1000, num_overlapping_elements: int = 0, min_chunk_size: int | None = None):
+        super().__init__(chunk_size=chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size)
         self.parser = PdfParser()
         # Reuse the DocumentChunker since it works on the hierarchical structure
-        self.chunker = DocumentChunker(chunk_size, num_overlapping_elements=num_overlapping_elements)
+        self.chunker = DocumentChunker(chunk_size, num_overlapping_elements=num_overlapping_elements, min_chunk_size=min_chunk_size)
 
     def process(self, file_input: str | BinaryIO) -> list[Chunk]:
         """Process PDF file and return chunks.

--- a/tests/test_chunk_homogenization.py
+++ b/tests/test_chunk_homogenization.py
@@ -1,0 +1,203 @@
+"""
+Tests for chunk size homogenization in DocumentChunker.
+
+These tests feed synthetic hierarchical node lists directly to
+DocumentChunker.apply() to verify:
+- Oversized paragraphs are split at sentence boundaries (with heading context).
+- Consecutive small paragraphs under the same heading context are merged.
+- Table and list container behavior is unchanged.
+- Boundary conditions (paragraph exactly at chunk_size, single tiny paragraph).
+"""
+
+from docchunker.processors.document_chunker import DocumentChunker
+
+
+def make_paragraph(content: str) -> dict:
+    return {"type": "paragraph", "content": content}
+
+
+def make_heading(content: str, level: int = 1, children: list | None = None) -> dict:
+    return {"type": "heading", "content": content, "level": level, "children": children or []}
+
+
+class TestOversizedParagraphSplitting:
+    def test_oversized_paragraph_is_split_at_sentence_boundaries(self):
+        chunker = DocumentChunker(chunk_size=200)
+        sentences = [f"This is sentence number {i} with some padding words." for i in range(12)]
+        long_paragraph = " ".join(sentences)
+        assert len(long_paragraph) > 200
+
+        nodes = [make_heading("Intro", 1, [make_paragraph(long_paragraph)])]
+        chunks = chunker.apply(nodes, "doc1")
+
+        assert len(chunks) > 1, "Oversized paragraph should be split into multiple chunks"
+        for chunk in chunks:
+            assert len(chunk.text) <= 200, f"Chunk exceeds chunk_size: {len(chunk.text)} chars"
+            assert chunk.metadata["node_type"] == "paragraph"
+            assert chunk.metadata["is_split"] is True
+            assert chunk.metadata["split_total"] == len(chunks)
+            assert chunk.metadata["headings"] == ["Intro"]
+            assert chunk.text.startswith("H1: Intro\n---\n"), "Each split chunk must carry the heading prefix"
+            assert chunk.metadata["num_chars"] == len(chunk.text)
+
+        assert [c.metadata["split_index"] for c in chunks] == list(range(len(chunks)))
+
+        # No sentence content is lost.
+        reconstructed = " ".join(c.text.split("---\n", 1)[1] for c in chunks)
+        assert reconstructed == long_paragraph
+
+    def test_split_pieces_end_at_sentence_boundaries(self):
+        chunker = DocumentChunker(chunk_size=200)
+        sentences = [f"Sentence {i} is here." for i in range(30)]
+        nodes = [make_paragraph(" ".join(sentences))]
+        chunks = chunker.apply(nodes, "doc1")
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk.text.rstrip().endswith("."), "Split pieces should end at a sentence boundary"
+
+    def test_single_overlong_sentence_falls_back_to_hard_split(self):
+        chunker = DocumentChunker(chunk_size=100)
+        giant_sentence = "x" * 350  # no sentence boundaries at all
+        chunks = chunker.apply([make_paragraph(giant_sentence)], "doc1")
+
+        assert len(chunks) == 4  # 350 chars / 100 available
+        for chunk in chunks:
+            assert len(chunk.text) <= 100
+            assert chunk.metadata["is_split"] is True
+        assert "".join(c.text for c in chunks) == giant_sentence
+
+    def test_paragraph_exactly_at_chunk_size_is_not_split(self):
+        chunker = DocumentChunker(chunk_size=100)
+        content = "a" * 100  # headings empty, so full chunk_size is available
+        chunks = chunker.apply([make_paragraph(content)], "doc1")
+
+        assert len(chunks) == 1
+        assert chunks[0].text == content
+        assert chunks[0].metadata["node_type"] == "paragraph"
+        assert "is_split" not in chunks[0].metadata
+
+    def test_split_accounts_for_heading_prefix_length(self):
+        chunker = DocumentChunker(chunk_size=120)
+        heading = "A fairly descriptive section heading"
+        content = ". ".join(["Some words here"] * 10) + "."
+        nodes = [make_heading(heading, 1, [make_paragraph(content)])]
+        chunks = chunker.apply(nodes, "doc1")
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk.text) <= 120, "Heading prefix must be counted against chunk_size"
+
+
+class TestUndersizedParagraphMerging:
+    def test_consecutive_tiny_paragraphs_are_merged(self):
+        chunker = DocumentChunker(chunk_size=1000)  # min_chunk_size defaults to 250
+        tiny_paragraphs = [f"Tiny paragraph {i}." for i in range(10)]
+        nodes = [make_heading("Section", 1, [make_paragraph(p) for p in tiny_paragraphs])]
+        chunks = chunker.apply(nodes, "doc1")
+
+        assert len(chunks) < 10, "Tiny paragraphs should be merged into fewer chunks"
+        merged = [c for c in chunks if c.metadata["node_type"] == "paragraph_group"]
+        assert merged, "Expected at least one merged paragraph_group chunk"
+        for chunk in merged:
+            assert chunk.metadata["num_merged_elements"] > 1
+            assert chunk.metadata["headings"] == ["Section"]
+            assert chunk.metadata["num_chars"] == len(chunk.text)
+            assert chunk.text.count("H1: Section") == 1, "Heading prefix must not be duplicated when merging"
+        total_merged = sum(c.metadata.get("num_merged_elements", 1) for c in chunks)
+        assert total_merged == 10, "No paragraph should be lost or duplicated"
+
+    def test_merged_chunks_stay_within_chunk_size(self):
+        chunker = DocumentChunker(chunk_size=300)
+        paragraphs = [f"Paragraph number {i} with a moderate amount of content in it." for i in range(20)]
+        nodes = [make_heading("Section", 1, [make_paragraph(p) for p in paragraphs])]
+        chunks = chunker.apply(nodes, "doc1")
+
+        for chunk in chunks:
+            assert len(chunk.text) <= 300
+
+    def test_paragraphs_under_different_headings_are_not_merged(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        nodes = [
+            make_heading("Section A", 1, [make_paragraph("Short one.")]),
+            make_heading("Section B", 1, [make_paragraph("Short two.")]),
+        ]
+        chunks = chunker.apply(nodes, "doc1")
+
+        assert len(chunks) == 2, "Paragraphs under different headings must not be merged"
+        assert chunks[0].metadata["headings"] == ["Section A"]
+        assert chunks[1].metadata["headings"] == ["Section B"]
+        assert all(c.metadata["node_type"] == "paragraph" for c in chunks)
+
+    def test_single_tiny_paragraph_stays_plain_paragraph(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        chunks = chunker.apply([make_heading("Section", 1, [make_paragraph("Just one tiny paragraph.")])], "doc1")
+
+        assert len(chunks) == 1
+        assert chunks[0].metadata["node_type"] == "paragraph"
+        assert "num_merged_elements" not in chunks[0].metadata
+        assert "is_split" not in chunks[0].metadata
+
+    def test_non_paragraph_node_breaks_merge_run(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        list_container = {
+            "type": "list_container",
+            "children": [{"type": "list_item", "content": "An item", "level": 0, "num_id": -1}],
+        }
+        nodes = [
+            make_heading("Section", 1, [
+                make_paragraph("Before the list."),
+                list_container,
+                make_paragraph("After the list."),
+            ])
+        ]
+        chunks = chunker.apply(nodes, "doc1")
+
+        node_types = [c.metadata["node_type"] for c in chunks]
+        assert node_types == ["paragraph", "list_container", "paragraph"], \
+            "Paragraphs separated by another element must not be merged across it"
+
+    def test_custom_min_chunk_size_controls_merging(self):
+        # min_chunk_size=1 effectively disables merging.
+        chunker = DocumentChunker(chunk_size=1000, min_chunk_size=1)
+        paragraphs = [f"Tiny {i}." for i in range(5)]
+        chunks = chunker.apply([make_paragraph(p) for p in paragraphs], "doc1")
+        assert len(chunks) == 5
+        assert all(c.metadata["node_type"] == "paragraph" for c in chunks)
+
+
+class TestExistingBehaviorUnchanged:
+    def test_table_chunking_unchanged(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        table = {
+            "type": "table",
+            "header": ["Name", "Value"],
+            "data_rows": [["alpha", "1"], ["beta", "2"]],
+        }
+        chunks = chunker.apply([make_heading("Data", 1, [table])], "doc1")
+
+        assert len(chunks) == 1
+        assert chunks[0].metadata["node_type"] == "table_rows"
+        assert "Name: alpha | Value: 1" in chunks[0].text
+        assert "is_split" not in chunks[0].metadata
+        assert "num_merged_elements" not in chunks[0].metadata
+
+    def test_list_container_chunking_unchanged(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        list_container = {
+            "type": "list_container",
+            "children": [
+                {"type": "list_item", "content": f"Item {i}", "level": 0, "num_id": -1}
+                for i in range(3)
+            ],
+        }
+        chunks = chunker.apply([make_heading("Lists", 1, [list_container])], "doc1")
+
+        assert len(chunks) == 1
+        assert chunks[0].metadata["node_type"] == "list_container"
+        assert "- Item 0" in chunks[0].text
+
+    def test_empty_paragraphs_are_skipped(self):
+        chunker = DocumentChunker(chunk_size=1000)
+        chunks = chunker.apply([make_paragraph("   "), make_paragraph("")], "doc1")
+        assert chunks == []


### PR DESCRIPTION
## Summary

Implements the **Chunk Size Homogenization** roadmap item with two purely rule-based mechanisms in `DocumentChunker` (no ML / layout detection):

### 1. Split oversized paragraphs
Resolves the long-standing TODO in `_consolidate_recursive`: a single paragraph whose heading prefix + content exceeds `chunk_size` is now split at sentence boundaries (regex `(?<=[.!?])\s+`), packing sentences greedily into pieces that fit the space left after the heading prefix. A hard character split is used only as a fallback when a single sentence alone exceeds the available space.
- Every piece carries the full heading prefix via `_create_chunk_text`.
- Metadata: `node_type: "paragraph"`, `is_split: true`, `split_index`, `split_total`.
- A paragraph exactly at `chunk_size` is not split.
- Sentence-level overlap was **not** implemented (kept simple as allowed by the task); `num_overlapping_elements` continues to apply to list items and table rows only.

### 2. Merge undersized paragraphs
Consecutive paragraph nodes under the same heading context are accumulated and flushed together (accumulate-then-flush inside the chunker, not a post-pass). Paragraphs are merged until the chunk reaches `min_chunk_size`, while the combined chunk always stays within `chunk_size`. Any non-paragraph node (heading, list, table) breaks the run, so merging never crosses heading contexts or other elements.
- Merged chunks: `node_type: "paragraph_group"`, `headings`, `num_chars`, `num_merged_elements`; the heading prefix is composed once (never duplicated).
- A single paragraph still produces a plain `node_type: "paragraph"` chunk with unchanged metadata.

### New parameter
`min_chunk_size` (default `chunk_size // 4`) added as an optional keyword on `DocChunker`, threaded through `DocxProcessor` / `PdfProcessor` / `BaseProcessor` to `DocumentChunker`. Documented in the README Configuration Parameters section. Setting it to `1` effectively disables merging. No other public API changes.

### Unchanged behavior
Table (`_process_table_node`) and list container (`_process_list_container`) chunking are untouched. Roadmap checkbox for Chunk Size Homogenization ticked (only that line).

## Before / after chunk-size distribution

Chunking `data/samples/complex_document.docx` and `data/unittests/nested_lists.docx` with `chunk_size=1000` (chars per chunk, all chunk types):

| Document | | n | min | median | max | stdev |
|---|---|---|---|---|---|---|
| complex_document.docx | before | 83 | 160 | 569 | 2065 | 381.5 |
| complex_document.docx | after | 79 | 160 | 623 | 2065 | 375.7 |
| nested_lists.docx | before | 14 | 26 | 98 | 955 | 262.4 |
| nested_lists.docx | after | 13 | 56 | 113 | 955 | 263.6 |

Restricted to paragraph chunks of `complex_document.docx` (the chunk type this PR targets): max drops from **1009 → 997** (the one oversized paragraph is now split) and n drops 48 → 44 via merging. The remaining >1000-char chunks in the "after" columns are single oversized table rows / list items, which are explicitly out of scope for this change. The effect on these particular sample docs is modest because their small paragraphs are rarely adjacent; the new unit tests demonstrate both mechanisms directly on synthetic node trees (splitting caps chunks at `chunk_size`, merging lifts runs of tiny paragraphs to `min_chunk_size+`).

## Testing

- New `tests/test_chunk_homogenization.py`: 14 focused tests feeding synthetic hierarchical nodes to `DocumentChunker.apply()` — sentence-boundary splitting with heading preservation and content round-trip, hard-split fallback, exact-`chunk_size` boundary, merging under same/different headings, merge run broken by lists, `min_chunk_size` override, unchanged table/list behavior, empty-paragraph handling.
- Full suite: **46 passed, 6 xfailed** (previously 32 passed, 6 xfailed — no existing test broken, no xfail count change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
