### PR TITLE
chore: remove leftover debug print in _format_table_row

### DIFF
--- a/docchunker/processors/document_chunker.py
+++ b/docchunker/processors/document_chunker.py
@@ -73,7 +73,6 @@ class DocumentChunker:
             try:
                 return " | ".join(row_data)
             except TypeError:
-                print(0)
                 raise ValueError("Row data must be a list of strings.")
         return " | ".join([f"{header[i]}: {cell_data}" for i, cell_data in enumerate(row_data)])
 


### PR DESCRIPTION
Tiny cleanup: removes a stray `print(0)` left in the `TypeError` fallback of `_format_table_row` in `docchunker/processors/document_chunker.py`. The `ValueError("Row data must be a list of strings.")` raise is kept — a test pins that contract.

Note: the second intended papercut (class docstring in `docchunker/chunker.py` claiming `chunk_size` default of 200) is already fixed on main (it reads "Default: 1000."), so this PR contains only the print removal.

Full suite: 218 passed, 6 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)